### PR TITLE
Do not use property value shorthand syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ function random() {
 }
 
 module.exports = {
-	names,
-	hex,
-	all,
-	random
+	names: names,
+	hex: hex,
+	all: all,
+	random: random
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "xo": "^0.17.0"
   },
   "xo": {
-    "esnext": true
+    "esnext": true,
+    "rules": {
+        "object-shorthand": ["error", "never"]
+    }
   }
 }


### PR DESCRIPTION
When trying to use html-colors as a dependency in a React app created using [create-react-app](https://github.com/facebookincubator/create-react-app) I was unable to build my project as UglisfyJS choked with the property value shorthand syntax used to export modules.

This PR modifies the module.exports syntax and disables eslint shorthand rule, enforced by xo.